### PR TITLE
refactor(API): getRetrieve method should retrieves only the record prop

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -246,7 +246,7 @@ const getRecord = function(res, args) {
     ids.forEach(id => {
         let record = records[id];
         if (record) {
-            result.push(record);
+            result.push(record._record);
         }
     })
 

--- a/src/api.js
+++ b/src/api.js
@@ -246,7 +246,7 @@ const getRecord = function(res, args) {
     ids.forEach(id => {
         let record = records[id];
         if (record) {
-            result.push(record._record);
+            result.push(record.obj);
         }
     })
 


### PR DESCRIPTION
Currently, the _getRecord_ API retrieves an array of objects with the following properties:

- _id
- _children
- _record
- _rtype

Probably the only information we need is __record_

**Note:**
__rtype_ and __id_ are already contained in the __record_ object