### PR TITLE
USE_CORS env variable to enable the CORS 

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -4,6 +4,8 @@ metadata:
   name: skupper-collector
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       application: skupper-collector

--- a/src/api.js
+++ b/src/api.js
@@ -24,6 +24,20 @@ const data = require('./data.js');
 const SERVER_PORT = 8010;
 const USE_CORS = process.env.USE_CORS
 
+const getHeaders = (props = {}) => {
+    const headers = {...props, 'Content-Type': 'application/json'}
+
+    if (USE_CORS === 'yes') {
+        return {
+            ...headers, 
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, PATCH, DELETE'
+        }
+    }
+
+    return headers
+}
+
 const traverseDepthFirst = function(record, result) {
     result.push(record.obj);
     record.children.forEach(child => {
@@ -89,13 +103,7 @@ const getVanAddrs = function(res, args) {
         result.push(value.obj);
     }
 
-    res.setHeader('Content-Type', 'application/json');
-
-    if (USE_CORS === 'yes') {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
-    }
-
+    res.writeHead(200, getHeaders());
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let watch = data.WatchRecord('VAN_ADDRESS', onRecordWatch, res);
@@ -120,12 +128,7 @@ const getVanAddrs = function(res, args) {
  * @param {*} args Arguments supplied with the GET query
  */
 const getFlows = function(res, args) {
-    res.setHeader('Content-Type', 'application/json');
-
-    if (USE_CORS === 'yes') {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
-    }
+    res.writeHead(200, getHeaders());
 
     if (!args.vanaddr) {
         badRequest(res, 'vanaddr argument missing');
@@ -183,13 +186,7 @@ const getRecordType = function(res, rType, args) {
     //
     // Send the JSON representation of the result.
     //
-    res.setHeader('Content-Type', 'application/json');
-
-    if (USE_CORS === 'yes') {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
-    }
-
+    res.writeHead(200, getHeaders());
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let watch = data.WatchRecord(rType, onRecordWatch, res);
@@ -240,13 +237,7 @@ const getTopology = function(res, args) {
     //
     // Send the JSON representation of the result.
     //
-    res.setHeader('Content-Type', 'application/json');
-
-    if (USE_CORS === 'yes') {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
-    }
-    
+    res.writeHead(200, getHeaders());
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let routerWatch = data.WatchRecord('ROUTER', onTopologyWatch, res);
@@ -273,7 +264,7 @@ const getRecord = function(res, args) {
         }
     })
 
-    res.setHeader('Content-Type', 'application/json');
+    res.writeHead(200, getHeaders());
     res.write(JSON.stringify(result));
     res.end();
 }

--- a/src/api.js
+++ b/src/api.js
@@ -22,7 +22,7 @@ const URL  = require('url');
 const data = require('./data.js');
 
 const SERVER_PORT = 8010;
-
+const USE_CORS = process.env.USE_CORS
 
 const traverseDepthFirst = function(record, result) {
     result.push(record.obj);
@@ -90,6 +90,12 @@ const getVanAddrs = function(res, args) {
     }
 
     res.setHeader('Content-Type', 'application/json');
+
+    if (USE_CORS === 'yes') {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
+    }
+
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let watch = data.WatchRecord('VAN_ADDRESS', onRecordWatch, res);
@@ -115,6 +121,11 @@ const getVanAddrs = function(res, args) {
  */
 const getFlows = function(res, args) {
     res.setHeader('Content-Type', 'application/json');
+
+    if (USE_CORS === 'yes') {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
+    }
 
     if (!args.vanaddr) {
         badRequest(res, 'vanaddr argument missing');
@@ -173,6 +184,12 @@ const getRecordType = function(res, rType, args) {
     // Send the JSON representation of the result.
     //
     res.setHeader('Content-Type', 'application/json');
+
+    if (USE_CORS === 'yes') {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
+    }
+
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let watch = data.WatchRecord(rType, onRecordWatch, res);
@@ -224,6 +241,12 @@ const getTopology = function(res, args) {
     // Send the JSON representation of the result.
     //
     res.setHeader('Content-Type', 'application/json');
+
+    if (USE_CORS === 'yes') {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE')
+    }
+    
     res.write(JSON.stringify(result));
     if (argsWatch(args)) {
         let routerWatch = data.WatchRecord('ROUTER', onTopologyWatch, res);


### PR DESCRIPTION
In the skupper controller, we can enable the CORS  by setting an env_variable
`kubectl set env deploy/skupper-service-controller USE_CORS=yes`

In this way, I can directly connect the FE with a remote Skupper Application without using proxies or browser plugins. 

Note: this modification has a development scope.
